### PR TITLE
Allow Shrine::Storage::Fog#url `public` default value to be set in the constructor

### DIFF
--- a/lib/shrine/storage/fog.rb
+++ b/lib/shrine/storage/fog.rb
@@ -7,10 +7,11 @@ class Shrine
     class Fog
       attr_reader :connection, :directory, :prefix
 
-      def initialize(directory:, prefix: nil, connection: nil, upload_options: {}, **options)
+      def initialize(directory:, prefix: nil, connection: nil, public_url: false, upload_options: {}, **options)
         @connection = connection || ::Fog::Storage.new(options)
         @directory = @connection.directories.new(key: directory)
         @prefix = prefix
+        @public_url = public_url
         @upload_options = upload_options
       end
 
@@ -36,7 +37,7 @@ class Shrine
         file(id).destroy
       end
 
-      def url(id, public: false, expires: 3600, **options)
+      def url(id, public: @public_url, expires: 3600, **options)
         signed_url = file(id).url(Time.now.utc + expires, *[**options])
 
         if public


### PR DESCRIPTION
Hi,
I want to use the public url of ObjectStorage files instead of the tempurl one, but I don't think that giving a `public: true` param to *every* call to `url` is a good idea.

So I was thinking that we could set the default value of `public` in the constructor of the storage : `public` can still be force to another value when calling `url`, but the default value will not always be `false`.